### PR TITLE
Consistency with !TWENTY_FOUR_BIT_COLOR in TEENSYDUINO

### DIFF
--- a/drivers/arduino/RGB_LED_Matrix_Lib/src/RGBLEDMatrix.cpp
+++ b/drivers/arduino/RGB_LED_Matrix_Lib/src/RGBLEDMatrix.cpp
@@ -293,12 +293,12 @@ void RGBLEDMatrix::incrementScanRow( void ) {
 	}
 }
 
-inline unsigned int multiplier5microseconds(void) const {
+inline unsigned int multiplier5microseconds( int scanPass ) const {
 	int mulitplier = 1;
 #if TWENTY_FOUR_BIT_COLOR
-	mulitplier = _scanPass/4+1;
+	mulitplier = scanPass/4+1;
 #else
-	switch (_scanPass) {
+	switch (scanPass) {
 		case 2:
 			mulitplier = 3;
 			break;
@@ -344,7 +344,7 @@ void stopScanning(void) {
 
 unsigned int RGBLEDMatrix::nextTimerInterval(void) const {
 	// Calculates the microseconds for each scan
-	int mulitplier = multiplier5microseconds();	
+	int mulitplier = multiplier5microseconds( _scanPass );	
 	
 	return  5*mulitplier;
 }
@@ -394,7 +394,7 @@ void stopScanning(void) {
 }
 
 unsigned int RGBLEDMatrix::nextTimerInterval(void) const {
-	return  max(257-multiplier5microseconds()*BASE_SCAN_TIMER_INTERVALS, 0 );
+	return  max(257-multiplier5microseconds( _scanPass )*BASE_SCAN_TIMER_INTERVALS, 0 );
 }
 
 

--- a/drivers/arduino/RGB_LED_Matrix_Lib/src/RGBLEDMatrix.cpp
+++ b/drivers/arduino/RGB_LED_Matrix_Lib/src/RGBLEDMatrix.cpp
@@ -293,6 +293,23 @@ void RGBLEDMatrix::incrementScanRow( void ) {
 	}
 }
 
+inline unsigned int multiplier5microseconds(void) const {
+	int mulitplier = 1;
+#if TWENTY_FOUR_BIT_COLOR
+	mulitplier = _scanPass/4+1;
+#else
+	switch (_scanPass) {
+		case 2:
+			mulitplier = 3;
+			break;
+		case 3:
+			mulitplier = 8;
+			break;
+	}
+#endif
+
+	return  mulitplier;
+}
 
 #if (defined(__arm__) && defined(TEENSYDUINO))
 //
@@ -327,7 +344,7 @@ void stopScanning(void) {
 
 unsigned int RGBLEDMatrix::nextTimerInterval(void) const {
 	// Calculates the microseconds for each scan
-	int mulitplier = _scanPass*1.25;	
+	int mulitplier = multiplier5microseconds();	
 	
 	return  5*mulitplier;
 }
@@ -377,21 +394,7 @@ void stopScanning(void) {
 }
 
 unsigned int RGBLEDMatrix::nextTimerInterval(void) const {
-	int mulitplier = 1;
-#if TWENTY_FOUR_BIT_COLOR
-	mulitplier = _scanPass/4+1;
-#else
-	switch (_scanPass) {
-		case 2:
-			mulitplier = 3;
-			break;
-		case 3:
-			mulitplier = 8;
-			break;
-	}
-#endif
-
-	return  max(257-mulitplier*BASE_SCAN_TIMER_INTERVALS, 0 );
+	return  max(257-multiplier5microseconds()*BASE_SCAN_TIMER_INTERVALS, 0 );
 }
 
 


### PR DESCRIPTION
The TEENSYDUINO code doesn't seem to handle the multiplier the same way as the Arduino code.  Probably the TEENSYDUINO is normally in TWENTY_FOUR_BIT_COLOR mode anyway, but seems to me this should be consistent - plus it moves code out of the hardware conditional.  I can't actually test compile this code, its typed in the browser.